### PR TITLE
Simplified ray cluster routing and fixed networking for monitoring

### DIFF
--- a/darwin-cluster-manager/charts/ray-cluster/templates/grafana.yaml
+++ b/darwin-cluster-manager/charts/ray-cluster/templates/grafana.yaml
@@ -10,8 +10,8 @@ stringData:
     default_timezone = Asia/Kolkata
     [server]
     domain = {{.Values.domain}}
-    root_url = %(protocol)s://%(domain)s:%(http_port)s{{.Values.grafana.rootPath}}
-    serve_from_sub_path = true
+    root_url = %(protocol)s://%(domain)s{{.Values.grafana.rootPath}}
+    serve_from_sub_path = false
     [auth.anonymous]
     enabled = true
     org_name = Main Org.

--- a/darwin-cluster-manager/charts/ray-cluster/templates/prometheus.yaml
+++ b/darwin-cluster-manager/charts/ray-cluster/templates/prometheus.yaml
@@ -15,8 +15,6 @@ spec:
       ray.io/cluster: {{ .Release.Name }}
   podMonitorNamespaceSelector: {}
   nodeSelector: {{- toYaml .Values.prometheus.nodeSelector | nindent 4 }}
-  imagePullSecrets:
-    - name: dsjfrog-platform
   podMetadata:
     labels: {{ include "ray-cluster.monitoring.labels" . | nindent 6 }}
     annotations:

--- a/darwin-cluster-manager/charts/ray-cluster/values.yaml
+++ b/darwin-cluster-manager/charts/ray-cluster/values.yaml
@@ -40,7 +40,7 @@ common:
     - name: RAY_GRAFANA_HOST
       value: http://id-test-grafana.prometheus.svc.cluster.local:3000
     - name: RAY_GRAFANA_IFRAME_HOST
-      value: https://localhost:30080/eks-0/id-test-metrics
+      value: https://localhost/eks-0/id-test-metrics
     - name: ENV
       value: id-test
     - name: CREATED_BY
@@ -457,7 +457,7 @@ user: darwin
 email: darwin@darwin.com
 cluster_name: id-test
 kube_cluster_key: eks-0
-domain: localhost:30080
+domain: localhost
 terminate_after_minutes: 60
 cluster_id: id-test
 TEAM_SUFFIX: -uat

--- a/darwin-compute/core/src/compute_core/constant/constants.py
+++ b/darwin-compute/core/src/compute_core/constant/constants.py
@@ -28,9 +28,9 @@ CONFIGS_MAP = {
         "jupyter_pods_threshold": 1,
         "jupyter_pods_max_idle_time": 5,
         "jupyter_pods_max_creation_time": 300,
-        "init_script_path": "http://localhost:30080/static/",
+        "init_script_path": "http://localhost/static/",
         "init_script_api": "http://darwin-compute.darwin.svc.cluster.local:8000/init-script-status",
-        "host_url": "localhost:30080",
+        "host_url": "localhost",
         "spark_history_server": {
             "s3_events_path": "s3a://darwin/darwin/temp/spark_history_server",
             "efs_events_path": "fsx/spark/eventlogs",

--- a/darwin-compute/core/src/compute_core/util/resources/values.yaml
+++ b/darwin-compute/core/src/compute_core/util/resources/values.yaml
@@ -395,7 +395,7 @@ service:
   type: ClusterIP
 
 grafana:
-  image: "000375658054.dkr.ecr.us-east-1.amazonaws.com/darwin:grafana"
+  image: "localhost:5000/grafana:latest"
   rootPath: "/eks-0/test-metrics/"
   nodeSelector:
     app: default
@@ -405,32 +405,32 @@ prometheus:
   nodeSelector:
     app: default
   remoteWrite:
-    - url: "http://darwin-thanos-receive-uat.dream11.local:10908/api/v1/receive"
+    - url: "http://darwin-thanos:10908/api/v1/receive"
 
 commands: [ ]
 sparkConfig: { }
 
 is_job_cluster: false
-env: stag
+env: local
 user: darwin
 email: darwin@test.com
 cluster_name: test-cluster
 kube_cluster_key: eks-0
-domain: darwin-mlp-stag.d11dev.com
+domain: localhost
 
-TEAM_SUFFIX: "-mlp-stag"
-VPC_SUFFIX: "-stag"
+TEAM_SUFFIX: ""
+VPC_SUFFIX: ""
 
 labels:
   project: darwin
   service: darwin
-  squad: data-science
-  environment: uat
+  squad: darwin
+  environment: local
 
 remoteCommand:
-  statusReportApi: "darwin-mlp-stag.d11dev.com/cluster/command/pod/status"
+  statusReportApi: "localhost/compute/cluster/command/pod/status"
   statusReportInterval: 10
-  logsS3Bucket: "d11-mlstag"
+  logsS3Bucket: "darwin"
   logsS3Key: "mlp/logs/remote-command"
   commands:
     head: [ ]

--- a/darwin-compute/core/src/compute_core/util/yaml_generator_v2/env_handler.py
+++ b/darwin-compute/core/src/compute_core/util/yaml_generator_v2/env_handler.py
@@ -77,7 +77,7 @@ def update_env_variables(values, compute_request, env, rss: bool = False):
         ),
         env_variable(
             "RAY_GRAFANA_IFRAME_HOST",
-            f"https://{CONFIGS_MAP[env]['host_url']}/{compute_request.cloud_env}/{compute_request.cluster_id}-metrics",
+            f"http://{CONFIGS_MAP[env]['host_url']}/{compute_request.cloud_env}/{compute_request.cluster_id}-metrics",
         ),
         env_variable("ENV", env),
         env_variable("CREATED_BY", compute_request.user),

--- a/helm/nginx-proxy-server/templates/nginx-config.yaml
+++ b/helm/nginx-proxy-server/templates/nginx-config.yaml
@@ -9,7 +9,14 @@ data:
     events {
       worker_connections 1024;
     }
+
     http {
+      # WebSocket connection upgrade mapping
+      map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+      }
+
       # Define upstream resolver for dynamic service discovery
       resolver kube-dns.kube-system.svc.cluster.local valid=10s;
 
@@ -52,7 +59,7 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
@@ -60,6 +67,7 @@ data:
           proxy_redirect      off;
           proxy_buffering     off;
           proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Redirect without trailing slash to with trailing slash for ray dashboard
@@ -78,7 +86,7 @@ data:
           proxy_pass http://$cluster_id-kuberay-head-svc.{{ .Values.global.rayClusterNamespace }}.svc.cluster.local:8265/$path$is_args$args;
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
@@ -99,13 +107,15 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto  $scheme;
           proxy_redirect      off;
           proxy_buffering     off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Spark UI - dynamic multi port routing
@@ -119,13 +129,15 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto  $scheme;
           proxy_redirect      off;
           proxy_buffering     off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Redirect without trailing slash to with trailing slash for vscode
@@ -145,7 +157,7 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
@@ -155,6 +167,8 @@ data:
           proxy_redirect      off;
           proxy_buffering     off;
           proxy_request_buffering off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Grafana - dynamic routing (different service pattern)
@@ -167,13 +181,15 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto  $scheme;
           proxy_redirect      off;
           proxy_buffering     off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Livy - dynamic routing
@@ -186,13 +202,15 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto  $scheme;
           proxy_redirect      off;
           proxy_buffering     off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Thrift - dynamic routing
@@ -205,13 +223,15 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto  $scheme;
           proxy_redirect      off;
           proxy_buffering     off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Custom services - dynamic routing with port mapping
@@ -235,13 +255,15 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto  $scheme;
           proxy_redirect      off;
           proxy_buffering     off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
 
         # Spark History Server - dynamic routing
@@ -254,13 +276,15 @@ data:
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade            $http_upgrade;
-          proxy_set_header Connection         "upgrade";
+          proxy_set_header Connection         $connection_upgrade;
           proxy_set_header Host               $host;
           proxy_set_header X-Real-IP          $remote_addr;
           proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto  $scheme;
           proxy_redirect      off;
           proxy_buffering     off;
+          proxy_read_timeout  86400;
+          proxy_send_timeout  86400;
         }
       }
     }

--- a/helm/nginx-proxy-server/values.yaml
+++ b/helm/nginx-proxy-server/values.yaml
@@ -45,9 +45,8 @@ nginx:
 
   # Service configuration
   service:
-    type: NodePort
+    type: ClusterIP
     port: 80
-    nodePort: 30080
     annotations: {}
 
   # Health check probes
@@ -101,13 +100,19 @@ serviceAccount:
   # Image pull secrets for the service account
   imagePullSecrets: []
 
-# Ingress configuration - disabled for local (using NodePort instead)
+# Ingress configuration
 ingress:
-  enabled: false
+  enabled: true
   internal:
-    enabled: false
-    annotations: {}
-    ingressClassName: ""
+    enabled: true
+    ingressClassName: nginx 
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    hosts:
+      - host: localhost
+        paths:
+          - path: "/eks-0(/|$)(.*)"
+            pathType: ImplementationSpecific
 
   external:
     enabled: false

--- a/kind/kind-config.yaml
+++ b/kind/kind-config.yaml
@@ -17,9 +17,6 @@ nodes:
     hostPort: 6443
     listenAddress: "127.0.0.1"
     protocol: TCP
-  - containerPort: 30080
-    hostPort: 30080
-    protocol: TCP
   extraMounts:
   - hostPath: ./kind/shared-storage
     containerPath: /mnt/shared-data


### PR DESCRIPTION
Simplified ray cluster routing and fixed networking for grafana and prometheus.

**Earlier Routes**: localhost:30080/eks-0/{cluster_id}-{service}/
**New Routes**: localhost/eks-0/{cluster_id}-{service}/