### PR TITLE
Feat/clean init sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -115,7 +115,7 @@ SERVICE_DATASTORES_darwin_cluster_manager="mysql opensearch localstack busybox"
 SERVICE_DATASTORES_darwin_workspace="mysql busybox"
 SERVICE_DATASTORES_ml_serve_app="mysql localstack busybox"
 SERVICE_DATASTORES_artifact_builder="mysql localstack busybox"
-SERVICE_DATASTORES_darwin_catalog="opensearch"
+SERVICE_DATASTORES_darwin_catalog="opensearch mysql"
 
 # ============================================================================
 # HELPER FUNCTIONS


### PR DESCRIPTION
Here is the depndency of the services on other services and datastores. 

darwin-ofs-v2
  - depends_on_services: darwin-ofs-v2-admin
  - depends_on_datastores: cassandra, mysql, busybox
darwin-ofs-v2-admin
  - depends_on_services:
  - depends_on_datastores: zookeeper, cassandra, mysql, localstack, kafka, busybox
darwin-ofs-v2-consumer
  - depends_on_services: darwin-ofs-v2-admin
  - depends_on_datastores: zookeeper, cassandra, mysql, localstack, kafka, busybox
darwin-mlflow
  - depends_on_services:
  - depends_on_datastores: mysql, localstack, busybox
darwin-mlflow-app
  - depends_on_services: darwin-mlflow
  - depends_on_datastores: mysql, localstack, busybox
chronos
  - depends_on_services:
  - depends_on_datastores: mysql, localstack, busybox, kafka, zookeeper
chronos-consumer
  - depends_on_services: chronos
  - depends_on_datastores: mysql, localstack, busybox, kafka, zookeeper
darwin-compute
  - depends_on_services: darwin-cluster-manager
  - depends_on_datastores: mysql, opensearch, busybox
darwin-cluster-manager
  - depends_on_services: 
  - depends_on_datastores: mysql, opensearch, localstack, busybox
darwin-workspace
  - depends_on_services: darwin-compute
  - depends_on_datastores: mysql, busybox
ml-serve-app
  - depends_on_services: artifact-builder
  - depends_on_datastores: mysql, localstack, busybox
artifact-builder
  - depends_on_services:
  - depends_on_datastores: mysql, localstack, busybox
darwin-catalog
  - depends_on_services:
  - depends_on_datastores: opensearch, sql
