### PR TITLE
Fixed Compute get library

### DIFF
--- a/darwin-compute/app_layer/src/compute_app_layer/routers/libraries_router.py
+++ b/darwin-compute/app_layer/src/compute_app_layer/routers/libraries_router.py
@@ -27,7 +27,7 @@ router = APIRouter(prefix="/cluster/{cluster_id}/library")
 @router.get("")
 async def get_libraries(
     cluster_id: str,
-    key: str = None,
+    key: Optional[str] = "",
     sort_by: Optional[str] = "id",
     sort_order: Optional[str] = "desc",
     offset: int = 0,


### PR DESCRIPTION
* Changed compute get library path from `/cluster/{cluster_id}/library/?key=` -> `/cluster/{cluster_id}/library`. Can also pass the key and other query parameters as usual
* Changed cluster library details path from `/cluster/{cluster_id}/library/{library_id}/` -> `/cluster/{cluster_id}/library/{library_id}`