### PR TITLE
Fix/darwin catalog (#29)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -115,7 +115,7 @@ SERVICE_DATASTORES_darwin_cluster_manager="mysql opensearch localstack busybox"
 SERVICE_DATASTORES_darwin_workspace="mysql busybox"
 SERVICE_DATASTORES_ml_serve_app="mysql localstack busybox"
 SERVICE_DATASTORES_artifact_builder="mysql localstack busybox"
-SERVICE_DATASTORES_darwin_catalog="opensearch mysql"
+SERVICE_DATASTORES_darwin_catalog="mysql localstack"
 
 # ============================================================================
 # HELPER FUNCTIONS


### PR DESCRIPTION
* fix: Workspace startup

* updated website link (#7)

* Simplified ray cluster routing and fixed networking of grafana and prometheus (#9)

* chore: optimize images and remove venv from setup scripts of ml-serve-app (#12)

* docs: update internal READMEs in ml-serve-app and artifact-builder (#18)

* fix(artifact-builder): auto-detect kind-registry port for image pushes (#20)

* updated contribmd (#23)

* Lighter compute images (#11)

* Made images lighter for compute and dcm

* fix(serve): persist serve, environment and artifact details when using one-click-deploy (#22)

* added db entries in one-click deployment

* Added artifact version for undeploy apis as well. Modified documentation

* Feat/clean init sh (#24)

* Develop (#15)

* fix: Workspace startup

* updated website link (#7)

* Simplified ray cluster routing and fixed networking of grafana and prometheus (#9)

* chore: optimize images and remove venv from setup scripts of ml-serve-app (#12)

---------






* updated the user functions to ensure better init

* updated catalog dependency with sql

---------






* Local cluster keyword rename (#13)

* Fixed local kind cluster keyword

* Added timeoutSeconds in zookeeper statefulset

* Fixed local storage mysql key value update issue for compute

* Fix migration issues

---------